### PR TITLE
feat:テストコードの実行 #6

### DIFF
--- a/patipuro-vscode/package.json
+++ b/patipuro-vscode/package.json
@@ -62,6 +62,10 @@
       {
         "command": "patipuro.runLint",
         "title": "PatiPro: Lint実行"
+      },
+      {
+        "command": "patipuro.runTest",
+        "title": "PatiPro: テスト実行"
       }
     ],
     "configuration": {
@@ -76,6 +80,11 @@
           "type": "string",
           "default": "npm run lint",
           "description": "PatiPro: Lint実行コマンド（コマンドパレットから実行する場合）"
+        },
+        "patipuro.testCommand": {
+          "type": "string",
+          "default": "npm test",
+          "description": "PatiPro: テスト実行コマンド（コマンドパレットから実行する場合）"
         },
         "patipuro.buildPatterns": {
           "type": "array",
@@ -108,6 +117,23 @@
             "dotnet format --verify-no-changes"
           ],
           "description": "ターミナルでのLintコマンドを検知するパターン（部分一致）"
+        },
+        "patipuro.testPatterns": {
+          "type": "array",
+          "items": { "type": "string" },
+          "default": [
+            "run test", "jest", "vitest",
+            "pytest", "python -m pytest",
+            "go test",
+            "cargo test",
+            "flutter test",
+            "dotnet test",
+            "gradle test", "gradlew test", "mvn test",
+            "rspec",
+            "phpunit",
+            "xcodebuild test"
+          ],
+          "description": "ターミナルでのテストコマンドを検知するパターン（部分一致）"
         }
       }
     }

--- a/patipuro-vscode/src/extension.ts
+++ b/patipuro-vscode/src/extension.ts
@@ -89,10 +89,11 @@ function updateStatusBar() {
 /**
  * シェルコマンドをVSCodeタスクとして実行し、終了コードに応じて弾を発射する
  */
-async function runPatiTask(commandKey: 'buildCommand' | 'lintCommand') {
+async function runPatiTask(commandKey: 'buildCommand' | 'lintCommand' | 'testCommand') {
     const config = vscode.workspace.getConfiguration('patipuro');
-    const cmd = config.get<string>(commandKey) ?? (commandKey === 'buildCommand' ? 'npm run build' : 'npm run lint');
-    const label = commandKey === 'buildCommand' ? 'ビルド' : 'Lint';
+    const defaultCmd = commandKey === 'buildCommand' ? 'npm run build' : commandKey === 'lintCommand' ? 'npm run lint' : 'npm test';
+    const cmd = config.get<string>(commandKey) ?? defaultCmd;
+    const label = commandKey === 'buildCommand' ? 'ビルド' : commandKey === 'lintCommand' ? 'Lint' : 'テスト';
 
     const task = new vscode.Task(
         { type: 'patipuro', command: commandKey },
@@ -145,6 +146,7 @@ export function activate(context: vscode.ExtensionContext) {
         const config = vscode.workspace.getConfiguration('patipuro');
         const buildPatterns = config.get<string[]>('buildPatterns') ?? ['run build', 'tsc', 'webpack', 'vite build'];
         const lintPatterns  = config.get<string[]>('lintPatterns')  ?? ['run lint', 'eslint', 'biome check', 'biome lint'];
+        const testPatterns  = config.get<string[]>('testPatterns')  ?? ['run test', 'jest', 'vitest', 'pytest'];
 
         shellExecDisposable = vscode.window.onDidEndTerminalShellExecution(e => {
             if (e.exitCode === undefined || e.exitCode !== 0) { return; }
@@ -152,6 +154,7 @@ export function activate(context: vscode.ExtensionContext) {
             const cmd = e.execution.commandLine.value;
             const isBuild = buildPatterns.some(p => cmd.includes(p));
             const isLint  = lintPatterns.some(p => cmd.includes(p));
+            const isTest  = testPatterns.some(p => cmd.includes(p));
 
             if (isBuild) {
                 postMessageToAll({ type: 'burst', count: 15 });
@@ -159,6 +162,9 @@ export function activate(context: vscode.ExtensionContext) {
             } else if (isLint) {
                 postMessageToAll({ type: 'burst', count: 10 });
                 vscode.window.showInformationMessage('✅ Lint通過！パチンコ放出！');
+            } else if (isTest) {
+                postMessageToAll({ type: 'burst', count: 20 });
+                vscode.window.showInformationMessage('🎯 テスト全通過！パチンコ大当たり！');
             }
         });
 
@@ -182,7 +188,12 @@ export function activate(context: vscode.ExtensionContext) {
         runPatiTask('lintCommand');
     });
 
-    context.subscriptions.push(startCmd, stopCmd, runBuildCmd, runLintCmd, statusBarItem);
+    // テスト実行コマンド
+    const runTestCmd = vscode.commands.registerCommand('patipuro.runTest', () => {
+        runPatiTask('testCommand');
+    });
+
+    context.subscriptions.push(startCmd, stopCmd, runBuildCmd, runLintCmd, runTestCmd, statusBarItem);
 }
 
 export function deactivate() {


### PR DESCRIPTION
## 関連issue
close #6

## 行った変更の説明

-変更点 
extension.ts                                                                                                                   
  - testPatterns の読み込み追加（jest, vitest, pytest など）                                                                     
  - ターミナルでテストコマンドが成功したとき burst: 20 発を放出（ビルドの15発より多め）                                          
  - patipuro.runTest コマンドを追加（コマンドパレットから直接テスト実行できる）                                                  
  - runPatiTask が testCommand にも対応                                                                                          
                                                                                                                                 
  package.json
  - patipuro.runTest コマンド定義を追加
  - patipuro.testCommand 設定（デフォルト: npm test）を追加
  - patipuro.testPatterns 設定を追加（jest, vitest, pytest, go test, cargo test など主要なテストフレームワークを網羅）

## スクショ、動画

- 

## メンバーに伝えること

- 
